### PR TITLE
Add documentation, Default impls & use C structs for structs with ambiguous fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,5 @@ edition = "2018"
 
 [dependencies]
 serde = {version = "1.0", features=["derive"]}
+[dev-dependencies]
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,6 @@ edition = "2018"
 
 [dependencies]
 serde = {version = "1.0", features=["derive"]}
+serde_tuple = "0.5.0"
 [dev-dependencies]
 serde_json = "1.0"

--- a/examples/definition.rs
+++ b/examples/definition.rs
@@ -16,7 +16,11 @@ fn main() {
         vec![
             Block::Header(
                 1,
-                Attr("a".to_owned(), vec![], vec![]),
+                Attr {
+                    identifier: "a".to_owned(),
+                    classes: vec![],
+                    attributes: vec![],
+                },
                 vec![Inline::Str("a".to_owned())],
             ),
             Block::Para(vec![Inline::Str("b".to_owned())]),

--- a/examples/definition.rs
+++ b/examples/definition.rs
@@ -1,10 +1,12 @@
+use std::collections::HashMap;
+
 use serde_json;
 
 use pandoc_types::definition::*;
 
 fn main() {
-    let mut meta = Meta::null();
-    meta.0.insert(
+    let mut meta = HashMap::default();
+    meta.insert(
         "title".to_owned(),
         MetaValue::MetaInlines(vec![Inline::Str("a".to_owned())]),
     );

--- a/src/definition.rs
+++ b/src/definition.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use serde::ser::SerializeStruct;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 const PANDOC_API_VERSION: [i32; 2] = [1, 22];
 
@@ -184,8 +185,13 @@ pub struct Row(pub Attr, pub Vec<Cell>);
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct TableHead(pub Attr, pub Vec<Row>);
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-pub struct TableBody(pub Attr, pub i32, pub Vec<Row>, pub Vec<Row>);
+#[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, PartialEq)]
+pub struct TableBody {
+    pub attr: Attr,
+    pub row_head_columns: i32,
+    pub head: Vec<Row>,
+    pub body: Vec<Row>,
+}
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct TableFoot(pub Attr, pub Vec<Row>);
@@ -193,11 +199,21 @@ pub struct TableFoot(pub Attr, pub Vec<Row>);
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Caption(pub Option<Vec<Inline>>, pub Vec<Block>);
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-pub struct Cell(pub Attr, pub Alignment, pub i32, pub i32, pub Vec<Block>);
+#[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, PartialEq)]
+pub struct Cell {
+    pub attr: Attr,
+    pub align: Alignment,
+    pub row_span: i32,
+    pub col_span: i32,
+    pub content: Vec<Block>,
+}
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-pub struct ListAttributes(pub i32, pub ListNumberStyle, pub ListNumberDelim);
+#[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, PartialEq)]
+pub struct ListAttributes {
+    pub start_number: i32,
+    pub style: ListNumberStyle,
+    pub delim: ListNumberDelim,
+}
 
 impl Default for ListAttributes {
     fn default() -> Self {
@@ -245,8 +261,12 @@ impl Default for ListNumberDelim {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Format(pub String);
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
-pub struct Attr(pub String, pub Vec<String>, pub Vec<(String, String)>);
+#[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, PartialEq, Default)]
+pub struct Attr {
+    pub identifier: String,
+    pub classes: Vec<String>,
+    pub attributes: Vec<(String, String)>,
+}
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(tag = "t", content = "c")]
@@ -255,8 +275,11 @@ pub enum QuoteType {
     DoubleQuote,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-pub struct Target(pub String, pub String);
+#[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, PartialEq)]
+pub struct Target {
+    pub url: String,
+    pub title: String,
+}
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(tag = "t", content = "c")]

--- a/src/definition.rs
+++ b/src/definition.rs
@@ -211,14 +211,8 @@ pub enum ListNumberDelim {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Format(pub String);
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct Attr(pub String, pub Vec<String>, pub Vec<(String, String)>);
-
-impl Attr {
-    pub fn null() -> Attr {
-        Attr(String::new(), Vec::new(), Vec::new())
-    }
-}
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(tag = "t", content = "c")]

--- a/src/definition.rs
+++ b/src/definition.rs
@@ -175,7 +175,7 @@ impl Default for ColWidth {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct ColSpec(pub Alignment, pub ColWidth);
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]

--- a/src/definition.rs
+++ b/src/definition.rs
@@ -75,17 +75,29 @@ pub enum MetaValue {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(tag = "t", content = "c")]
 pub enum Block {
+    /// Plain text, not a paragraph
     Plain(Vec<Inline>),
+    /// Paragraph
     Para(Vec<Inline>),
+    /// Multiple non-breaking lines
     LineBlock(Vec<Vec<Inline>>),
+    /// Code block (literal) with attributes
     CodeBlock(Attr, String),
+    /// Raw block
     RawBlock(Format, String),
+    /// Block quote
     BlockQuote(Vec<Block>),
+    /// Ordered list (attributes and a list of items, each a list of blocks)
     OrderedList(ListAttributes, Vec<Vec<Block>>),
+    /// Bullet list (list of items, each a list of blocks)
     BulletList(Vec<Vec<Block>>),
+    /// Definition list. Each list item is a pair consisting of a term (a list of inlines) and one or more definitions (each a list of blocks)
     DefinitionList(Vec<(Vec<Inline>, Vec<Vec<Block>>)>),
+    /// Header - level (integer) and text (inlines)
     Header(i32, Attr, Vec<Inline>),
+    /// Horizontal rule
     HorizontalRule,
+    /// Table, with attributes, caption, optional short caption, column alignments and widths (required), table head, table bodies, and table foot
     Table(
         Attr,
         Caption,
@@ -94,32 +106,54 @@ pub enum Block {
         Vec<TableBody>,
         TableFoot,
     ),
+    /// Generic block container with attributes
     Div(Attr, Vec<Block>),
+    /// Nothing
     Null,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(tag = "t", content = "c")]
 pub enum Inline {
+    /// Text
     Str(String),
+    /// Emphasized text
     Emph(Vec<Inline>),
+    /// Underlined text
     Underline(Vec<Inline>),
+    /// Strongly emphasized text
     Strong(Vec<Inline>),
+    /// Strikeout text
     Strikeout(Vec<Inline>),
+    /// Superscripted text
     Superscript(Vec<Inline>),
+    /// Subscripted text
     Subscript(Vec<Inline>),
+    /// Small caps text
     SmallCaps(Vec<Inline>),
+    /// Quoted text
     Quoted(QuoteType, Vec<Inline>),
+    /// Citation
     Cite(Vec<Citation>, Vec<Inline>),
+    /// Inline code
     Code(Attr, String),
+    /// Inter-word space
     Space,
+    /// Soft line break
     SoftBreak,
+    /// Hard line break
     LineBreak,
+    /// TeX math
     Math(MathType, String),
+    /// Raw inline
     RawInline(Format, String),
+    /// Hyperlink: alt text (list of inlines), target
     Link(Attr, Vec<Inline>, Target),
+    /// Image: alt text (list of inlines), target
     Image(Attr, Vec<Inline>, Target),
+    /// Footnote or endnote
     Note(Vec<Block>),
+    /// Generic inline container with attributes
     Span(Attr, Vec<Inline>),
 }
 

--- a/src/definition.rs
+++ b/src/definition.rs
@@ -248,18 +248,13 @@ pub enum MathType {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
 pub struct Citation {
-    #[serde(rename = "citationId")]
     pub citation_id: String,
-    #[serde(rename = "citationPrefix")]
     pub citation_prefix: Vec<Inline>,
-    #[serde(rename = "citationSuffix")]
     pub citation_suffix: Vec<Inline>,
-    #[serde(rename = "citationMode")]
     pub citation_mode: CitationMode,
-    #[serde(rename = "citationNoteNum")]
     pub citation_note_num: i32,
-    #[serde(rename = "citationHash")]
     pub citation_hash: i32,
 }
 

--- a/src/definition.rs
+++ b/src/definition.rs
@@ -156,11 +156,23 @@ pub enum Alignment {
     AlignDefault,
 }
 
+impl Default for Alignment {
+    fn default() -> Self {
+        Self::AlignDefault
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(tag = "t", content = "c")]
 pub enum ColWidth {
     ColWidth(f64),
     ColWidthDefault,
+}
+
+impl Default for ColWidth {
+    fn default() -> Self {
+        Self::ColWidthDefault
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -187,6 +199,16 @@ pub struct Cell(pub Attr, pub Alignment, pub i32, pub i32, pub Vec<Block>);
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct ListAttributes(pub i32, pub ListNumberStyle, pub ListNumberDelim);
 
+impl Default for ListAttributes {
+    fn default() -> Self {
+        Self {
+            start_number: 1,
+            style: ListNumberStyle::default(),
+            delim: ListNumberDelim::default(),
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(tag = "t", content = "c")]
 pub enum ListNumberStyle {
@@ -199,6 +221,12 @@ pub enum ListNumberStyle {
     UpperAlpha,
 }
 
+impl Default for ListNumberStyle {
+    fn default() -> Self {
+        Self::DefaultStyle
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(tag = "t", content = "c")]
 pub enum ListNumberDelim {
@@ -206,6 +234,12 @@ pub enum ListNumberDelim {
     Period,
     OneParen,
     TwoParens,
+}
+
+impl Default for ListNumberDelim {
+    fn default() -> Self {
+        Self::DefaultDelim
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]

--- a/src/definition.rs
+++ b/src/definition.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 const PANDOC_API_VERSION: [i32; 2] = [1, 22];
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct Pandoc(pub Meta, pub Vec<Block>);
+pub struct Pandoc(pub HashMap<String, MetaValue>, pub Vec<Block>);
 
 impl Serialize for Pandoc {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -29,7 +29,7 @@ impl<'a> Deserialize<'a> for Pandoc {
         #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
         #[serde(rename = "Pandoc")]
         struct Inner {
-            meta: Meta,
+            meta: HashMap<String, MetaValue>,
             blocks: Vec<Block>,
             #[serde(rename = "pandoc-api-version")]
             version: Vec<i32>,
@@ -48,23 +48,6 @@ impl<'a> Deserialize<'a> for Pandoc {
         }
 
         Ok(Pandoc(value.meta, value.blocks))
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-pub struct Meta(pub HashMap<String, MetaValue>);
-
-impl Meta {
-    pub fn null() -> Meta {
-        Meta(HashMap::new())
-    }
-
-    pub fn is_null(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    pub fn lookup(&self, key: &str) -> Option<&MetaValue> {
-        self.0.get(key)
     }
 }
 
@@ -277,11 +260,6 @@ pub enum CitationMode {
 mod tests {
     use super::*;
     use serde_json::json;
-
-    #[test]
-    fn meta_null() {
-        assert!(Meta::null().is_null());
-    }
 
     #[test]
     fn version() {

--- a/tests/definition.rs
+++ b/tests/definition.rs
@@ -1,6 +1,0 @@
-use pandoc_types::definition::*;
-
-#[test]
-fn meta_null() {
-    assert!(Meta::null().is_null());
-}


### PR DESCRIPTION
Hey, thanks for your library ... I made a bunch of changes to make the API more comfortable.

This PR introduces the following breaking changes:

* `HashMap<String, MetaValue>` isn't newtyped anymore since the newtype didn't add anything
* no more `null` methods ... implement `std::default::Default` instead
* use C structs for structs where tuple structs lack clarity (what's that i32? what's that String?)

If you like these changes, please merge them without squashing.