### PR TITLE
Update Pandoc API to 1.23

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup pandoc
         uses: r-lib/actions/setup-pandoc@v1
         with:
-          pandoc-version: 2.17.1.1
+          pandoc-version: 3.1
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pandoc_types"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Elliott Slaughter <elliottslaughter@gmail.com>"]
 license = "Apache-2.0"
 description = "Rust port of pandoc-types"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ To install, add the following to your `Cargo.toml`:
 
 ```
 [dependencies]
-pandoc_types = "0.5"
+pandoc_types = "0.6"
 ```
 
 ## What this library is for
@@ -29,7 +29,7 @@ itself. If that's what you're looking for, consider the
 ## Compatibility
 
 The current version is **compatible with Haskell pandoc-types
-1.22**. This is the most recent version at the time of writing.
+1.23**. This is the most recent version at the time of writing.
 
 ## Supported modules
 

--- a/src/definition.rs
+++ b/src/definition.rs
@@ -11,7 +11,7 @@ use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 pub mod extra;
 mod iter;
 
-const PANDOC_API_VERSION: [i32; 2] = [1, 22];
+const PANDOC_API_VERSION: [i32; 2] = [1, 23];
 
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct Pandoc {
@@ -103,6 +103,8 @@ pub enum Block {
     HorizontalRule,
     /// Table
     Table(Table),
+    /// Figure
+    Figure(Attr, Caption, Vec<Block>),
     /// Generic block container with attributes
     Div(Attr, Vec<Block>),
     /// Nothing

--- a/src/definition/extra.rs
+++ b/src/definition/extra.rs
@@ -46,6 +46,7 @@ pub enum BlockType {
     Header,
     HorizontalRule,
     Table,
+    Figure,
     Div,
     Null,
 }
@@ -65,6 +66,7 @@ impl From<&Block> for BlockType {
             Block::Header(_, _, _) => Self::Header,
             Block::HorizontalRule => Self::HorizontalRule,
             Block::Table(_) => Self::Table,
+            Block::Figure(_, _, _) => Self::Figure,
             Block::Div(_, _) => Self::Div,
             Block::Null => Self::Null,
         }

--- a/src/definition/iter.rs
+++ b/src/definition/iter.rs
@@ -31,6 +31,7 @@ impl<'a> IterBlocks<'a> for Block {
     fn iter_blocks(&'a self) -> Self::Iter {
         Box::new(match self {
             Block::BlockQuote(blocks) => IterTypes::Iter(blocks.iter()),
+            Block::Figure(_, _, blocks) => IterTypes::Iter(blocks.iter()),
             Block::Div(_, blocks) => IterTypes::Iter(blocks.iter()),
             Block::BulletList(items) => IterTypes::FlattenIter(items.iter().flatten()),
             Block::OrderedList(_, items) => IterTypes::FlattenIter(items.iter().flatten()),
@@ -55,6 +56,7 @@ impl<'a> IterBlocks<'a> for Block {
     fn iter_blocks_mut(&'a mut self) -> Self::IterMut {
         Box::new(match self {
             Block::BlockQuote(blocks) => IterTypes::Iter(blocks.iter_mut()),
+            Block::Figure(_, _, blocks) => IterTypes::Iter(blocks.iter_mut()),
             Block::Div(_, blocks) => IterTypes::Iter(blocks.iter_mut()),
             Block::BulletList(items) => IterTypes::FlattenIter(items.iter_mut().flatten()),
             Block::OrderedList(_, items) => IterTypes::FlattenIter(items.iter_mut().flatten()),
@@ -176,6 +178,7 @@ impl<'a> IterInlines<'a> for Block {
             Block::OrderedList(_, _) => IterTypes::Empty,
             Block::BulletList(_) => IterTypes::Empty,
             Block::HorizontalRule => IterTypes::Empty,
+            Block::Figure(_, _, _) => IterTypes::Empty,
             Block::Div(_, _) => IterTypes::Empty,
             Block::Null => IterTypes::Empty,
         })
@@ -200,6 +203,7 @@ impl<'a> IterInlines<'a> for Block {
             Block::OrderedList(_, _) => IterTypes::Empty,
             Block::BulletList(_) => IterTypes::Empty,
             Block::HorizontalRule => IterTypes::Empty,
+            Block::Figure(_, _, _) => IterTypes::Empty,
             Block::Div(_, _) => IterTypes::Empty,
             Block::Null => IterTypes::Empty,
         })

--- a/tests/testsuite_uppercase.txt
+++ b/tests/testsuite_uppercase.txt
@@ -727,7 +727,10 @@ AUTO-LINKS SHOULD NOT OCCUR HERE: `<http://example.com/>`
 
 FROM "VOYAGE DANS LA LUNE" BY GEORGES MELIES (1902):
 
-![LALUNE](lalune.jpg "Voyage dans la Lune")
+<figure>
+<img src="lalune.jpg" title="Voyage dans la Lune" alt="LALUNE" />
+<figcaption>lalune</figcaption>
+</figure>
 
 HERE IS A MOVIE ![MOVIE](movie.jpg) ICON.
 


### PR DESCRIPTION
pandoc-types recently got a new minor version (1.23, see https://github.com/jgm/pandoc-types/blob/master/changelog) which added a `Figure` block.

This pull request adds this block type and the slight change in the testcase output (one of the images produced different output, preserving more of the input attributes, nothing else changed).  
It also changes the minor version since this is a breaking change (pandoc only accepts the API version it was build with).

Since I could not detect any particular ordering, I added the new enum variants and match arms at the bottom. If there is a specific order I can change the pull request.